### PR TITLE
chore: bump services versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: deploy remove build
 
-STACK_NAME ?= cfa_opencti
-COMPOSE_FILE?= docker-compose.yml
-NGINX_VERSION?=1.26.0 #based off Nginx docker  version
+STACK_NAME?=nginx-opencti
+COMPOSE_FILE?=docker-compose.yml
+NGINX_VERSION?=0.0.7 #based off Nginx docker  version
 
 # build Nginx image & push to dockerhub
 build:
-	docker buildx build --platform linux/amd64 -t codeforafrica/cfa-opencti-nginx:$(NGINX_VERSION) --file nginx/Dockerfile nginx/ --push
+	docker buildx build -t codeforafrica/$(STACK_NAME):$(NGINX_VERSION) --file nginx/Dockerfile nginx/ --push
 
 # deploy openCTI stack
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 STACK_NAME?=nginx-opencti
 COMPOSE_FILE?=docker-compose.yml
-NGINX_VERSION?=0.0.7 #based off Nginx docker  version
+NGINX_VERSION?=1.27.0 #based off Nginx docker  version
 
 # build Nginx image & push to dockerhub
 build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - APP__ADMIN__EMAIL=${OPENCTI_ADMIN_EMAIL}
       - APP__ADMIN__PASSWORD=${OPENCTI_ADMIN_PASSWORD}
       - APP__ADMIN__TOKEN=${OPENCTI_ADMIN_TOKEN}
-      - APP__APP_LOGS__LOGS_LEVEL=debug
+      - APP__APP_LOGS__LOGS_LEVEL=error
       - APP__APP_LOGS__LOGS_CONSOLE=true # Output in the container console
       - REDIS__HOSTNAME=redis
       - REDIS__PORT=6379
@@ -115,7 +115,7 @@ services:
       - CONNECTOR_SCOPE=application/json
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_LOG_LEVEL=error
     restart: always
     depends_on:
       - opencti
@@ -199,7 +199,7 @@ services:
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
-      - CONNECTOR_ID=c3970f8a-ce4b-4497-a381-20b7256f56f0 # Valid UUIDv4
+      - CONNECTOR_ID=${CONNECTOR_IMPORT_DOCUMENT_ID} # Valid UUIDv4
       - CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
       - CONNECTOR_NAME=ImportDocument
       - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
@@ -207,7 +207,7 @@ services:
       - CONNECTOR_AUTO=true # Enable/disable auto-import of file
       - CONNECTOR_ONLY_CONTEXTUAL=false # Only extract data related to an entity (a report, a threat actor, etc.)
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=error
+      - CONNECTOR_LOG_LEVEL=debug
       - IMPORT_DOCUMENT_CREATE_INDICATOR=true
     restart: always
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - redisdata:/data
       
   nginx:
-    image: codeforafrica/cfa-opencti:0.0.6
+    image: codeforafrica/nginx-opencti:0.0.7
     deploy:
       replicas: 1
       placement:
@@ -211,7 +211,7 @@ services:
       - CONNECTOR_AUTO=true # Enable/disable auto-import of file
       - CONNECTOR_ONLY_CONTEXTUAL=false # Only extract data related to an entity (a report, a threat actor, etc.)
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
-      - CONNECTOR_LOG_LEVEL=debug
+      - CONNECTOR_LOG_LEVEL=error
       - IMPORT_DOCUMENT_CREATE_INDICATOR=true
     depends_on:
       - opencti

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
 version: '3'
+
+x-restart-policy: &default_restart_policy
+  condition: on-failure
+  delay: 3s
+  max_attempts: 5
+  window: 60s
 services:
   redis:
     deploy:
@@ -7,7 +13,7 @@ services:
         constraints:
         - node.labels.role == opencti-core
     image: redis:7.4.2
-    restart: always
+    restart_policy: *default_restart_policy
     volumes:
       - redisdata:/data
       
@@ -31,7 +37,7 @@ services:
       - RABBITMQ_NODENAME=rabbit01@localhost
     volumes:
       - amqpdata:/var/lib/rabbitmq
-    restart: always
+    restart_policy: *default_restart_policy
     deploy:
       placement:
         constraints:
@@ -79,7 +85,7 @@ services:
     depends_on:
       - redis
       - rabbitmq 
-    restart: always
+    restart_policy: *default_restart_policy
 
   worker:
     image: opencti/worker:6.5.3
@@ -116,7 +122,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
       - CONNECTOR_LOG_LEVEL=error
-    restart: always
+    restart_policy: *default_restart_policy
     depends_on:
       - opencti
       - rabbitmq
@@ -138,7 +144,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
       - CONNECTOR_LOG_LEVEL=info
-    restart: always
+    restart_policy: *default_restart_policy
     depends_on:
       - opencti
       - rabbitmq
@@ -160,7 +166,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
       - CONNECTOR_LOG_LEVEL=info
-    restart: always
+    restart_policy: *default_restart_policy
     depends_on:
       - opencti
       - rabbitmq
@@ -184,7 +190,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
       - CONNECTOR_LOG_LEVEL=info
-    restart: always
+    restart_policy: *default_restart_policy
     depends_on:
       - opencti
       - rabbitmq
@@ -209,7 +215,7 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=debug
       - IMPORT_DOCUMENT_CREATE_INDICATOR=true
-    restart: always
+    restart_policy: *default_restart_policy
     depends_on:
       - opencti
       - rabbitmq
@@ -233,7 +239,7 @@ services:
       - CONNECTOR_LOG_LEVEL=info
       - DISARM_FRAMEWORK_URL=https://raw.githubusercontent.com/DISARMFoundation/DISARMframeworks/main/generated_files/DISARM_STIX/DISARM.json
       - DISARM_FRAMEWORK_INTERVAL=7 # In days, must be strictly greater than 1
-    restart: always
+    restart_policy: *default_restart_policy
     depends_on:
       - opencti
       - rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ x-restart-policy: &default_restart_policy
   delay: 3s
   max_attempts: 5
   window: 60s
+
 services:
   redis:
     deploy:
@@ -12,8 +13,8 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: redis:7.4.2
-    restart_policy: *default_restart_policy
     volumes:
       - redisdata:/data
       
@@ -30,6 +31,11 @@ services:
       - opencti
 
   rabbitmq:
+    deploy:
+      placement:
+        constraints:
+          - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: rabbitmq:4.0-management
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
@@ -37,11 +43,6 @@ services:
       - RABBITMQ_NODENAME=rabbit01@localhost
     volumes:
       - amqpdata:/var/lib/rabbitmq
-    restart_policy: *default_restart_policy
-    deploy:
-      placement:
-        constraints:
-          - node.labels.role == opencti-core
 
   opencti:
     deploy:
@@ -49,6 +50,7 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/platform:6.5.3
     environment:
       - NODE_OPTIONS=--max-old-space-size=8096
@@ -62,7 +64,7 @@ services:
       - REDIS__HOSTNAME=redis
       - REDIS__PORT=6379
       - ELASTICSEARCH__SSL__REJECT_UNAUTHORIZED="false"
-      - "ELASTICSEARCH__URL=[\"https://${ELASTIC_USER}:${ELASTICPASSWORD}@${ELASTIC_IP_1}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTICPASSWORD}@${ELASTIC_IP_2}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTICPASSWORD}@${ELASTIC_IP_3}:${ELASTIC_PORT}\"]"
+      - "ELASTICSEARCH__URL=[\"https://${ELASTIC_USER}:${ELASTIC_PASSWORD}@${ELASTIC_IP_1}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTIC_PASSWORD}@${ELASTIC_IP_2}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTIC_PASSWORD}@${ELASTIC_IP_3}:${ELASTIC_PORT}\"]"
       - ELASTICSEARCH__INDEX_PREFIX=opencti
       - MINIO__ENDPOINT=${MINIO__ENDPOINT}
       - MINIO__PORT=${MINIO__PORT}
@@ -85,9 +87,15 @@ services:
     depends_on:
       - redis
       - rabbitmq 
-    restart_policy: *default_restart_policy
 
   worker:
+    deploy:
+      mode: replicated
+      replicas: 3
+      placement:
+        constraints:
+          - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/worker:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
@@ -95,15 +103,7 @@ services:
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
       - WORKER_LOG_LEVEL=error
     depends_on:
-      - opencti
-      - rabbitmq 
-    deploy:
-      mode: replicated
-      replicas: 3
-      placement:
-        constraints:
-          - node.labels.role == opencti-core
-    restart: always
+      - opencti 
     
   connector-export-file-stix:
     deploy:
@@ -111,6 +111,7 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/connector-export-file-stix:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
@@ -122,10 +123,8 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
       - CONNECTOR_LOG_LEVEL=error
-    restart_policy: *default_restart_policy
     depends_on:
-      - opencti
-      - rabbitmq
+      - opencti 
 
   connector-export-file-csv:
     deploy:
@@ -133,6 +132,7 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/connector-export-file-csv:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
@@ -143,11 +143,9 @@ services:
       - CONNECTOR_SCOPE=text/csv
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info
-    restart_policy: *default_restart_policy
+      - CONNECTOR_LOG_LEVEL=error
     depends_on:
       - opencti
-      - rabbitmq
 
   connector-export-file-txt:
     deploy:
@@ -155,6 +153,7 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/connector-export-file-txt:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
@@ -165,11 +164,10 @@ services:
       - CONNECTOR_SCOPE=text/plain
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info
-    restart_policy: *default_restart_policy
+      - CONNECTOR_LOG_LEVEL=error
     depends_on:
       - opencti
-      - rabbitmq
+      
 
   connector-import-file-stix:
     deploy:
@@ -177,6 +175,7 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/connector-import-file-stix:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
@@ -189,11 +188,9 @@ services:
       - CONNECTOR_AUTO=true # Enable/disable auto-import of file
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info
-    restart_policy: *default_restart_policy
+      - CONNECTOR_LOG_LEVEL=error
     depends_on:
-      - opencti
-      - rabbitmq
+      - opencti  
       
   connector-import-document:
     deploy:
@@ -201,6 +198,7 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/connector-import-document:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
@@ -215,10 +213,8 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_LOG_LEVEL=debug
       - IMPORT_DOCUMENT_CREATE_INDICATOR=true
-    restart_policy: *default_restart_policy
     depends_on:
       - opencti
-      - rabbitmq
     
   connector-disarm-framework:
     deploy:
@@ -226,6 +222,7 @@ services:
       placement:
         constraints:
         - node.labels.role == opencti-core
+      restart_policy: *default_restart_policy
     image: opencti/connector-disarm-framework:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
@@ -236,13 +233,11 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=75 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_RUN_AND_TERMINATE=false
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info
+      - CONNECTOR_LOG_LEVEL=error
       - DISARM_FRAMEWORK_URL=https://raw.githubusercontent.com/DISARMFoundation/DISARMframeworks/main/generated_files/DISARM_STIX/DISARM.json
       - DISARM_FRAMEWORK_INTERVAL=7 # In days, must be strictly greater than 1
-    restart_policy: *default_restart_policy
     depends_on:
       - opencti
-      - rabbitmq
 
 # volumes:
 #    esdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,58 +1,49 @@
 version: '3'
-
 services:
   redis:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: &default_restart_policy
-        condition: on-failure
-        delay: 3s
-        max_attempts: 5
-        window: 60s
-    image: redis:7.2.4
-
+        - node.labels.role == opencti-core
+    image: redis:7.4.2
+    restart: always
     volumes:
       - redisdata:/data
-
+      
   nginx:
     image: codeforafrica/cfa-opencti:0.0.6
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == manager
-      restart_policy: *default_restart_policy
+        - node.labels.role == manager
     ports:
       - "80:80"
     depends_on:
       - opencti
 
   rabbitmq:
-    image: rabbitmq:3.13-management
-    deploy:
-      replicas: 1
-      placement:
-        constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
+    image: rabbitmq:4.0-management
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
       - RABBITMQ_NODENAME=rabbit01@localhost
     volumes:
       - amqpdata:/var/lib/rabbitmq
+    restart: always
+    deploy:
+      placement:
+        constraints:
+          - node.labels.role == opencti-core
 
   opencti:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-    image: opencti/platform:6.1.1
+        - node.labels.role == opencti-core
+    image: opencti/platform:6.5.3
     environment:
       - NODE_OPTIONS=--max-old-space-size=8096
       - APP__PORT=8080
@@ -60,12 +51,12 @@ services:
       - APP__ADMIN__EMAIL=${OPENCTI_ADMIN_EMAIL}
       - APP__ADMIN__PASSWORD=${OPENCTI_ADMIN_PASSWORD}
       - APP__ADMIN__TOKEN=${OPENCTI_ADMIN_TOKEN}
-      - APP__APP_LOGS__LOGS_LEVEL=error
+      - APP__APP_LOGS__LOGS_LEVEL=debug
       - APP__APP_LOGS__LOGS_CONSOLE=true # Output in the container console
       - REDIS__HOSTNAME=redis
       - REDIS__PORT=6379
       - ELASTICSEARCH__SSL__REJECT_UNAUTHORIZED="false"
-      - "ELASTICSEARCH__URL=[\"https://${ELASTIC_USER}:${ELASTIC_PASSWORD}@${ELASTIC_IP_1}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTIC_PASSWORD}@${ELASTIC_IP_2}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTIC_PASSWORD}@${ELASTIC_IP_3}:${ELASTIC_PORT}\"]"
+      - "ELASTICSEARCH__URL=[\"https://${ELASTIC_USER}:${ELASTICPASSWORD}@${ELASTIC_IP_1}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTICPASSWORD}@${ELASTIC_IP_2}:${ELASTIC_PORT}\", \"https://${ELASTIC_USER}:${ELASTICPASSWORD}@${ELASTIC_IP_3}:${ELASTIC_PORT}\"]"
       - ELASTICSEARCH__INDEX_PREFIX=opencti
       - MINIO__ENDPOINT=${MINIO__ENDPOINT}
       - MINIO__PORT=${MINIO__PORT}
@@ -87,11 +78,11 @@ services:
       - "8080:8080"
     depends_on:
       - redis
-      - rabbitmq
-
+      - rabbitmq 
+    restart: always
 
   worker:
-    image: opencti/worker:6.1.1
+    image: opencti/worker:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
@@ -99,22 +90,22 @@ services:
       - WORKER_LOG_LEVEL=error
     depends_on:
       - opencti
+      - rabbitmq 
     deploy:
       mode: replicated
       replicas: 3
       placement:
         constraints:
           - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-
+    restart: always
+    
   connector-export-file-stix:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-    image: opencti/connector-export-file-stix:6.1.1
+        - node.labels.role == opencti-core
+    image: opencti/connector-export-file-stix:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
@@ -124,18 +115,19 @@ services:
       - CONNECTOR_SCOPE=application/json
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info=error
+      - CONNECTOR_LOG_LEVEL=info
+    restart: always
     depends_on:
       - opencti
+      - rabbitmq
 
   connector-export-file-csv:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-    image: opencti/connector-export-file-csv:6.1.1
+        - node.labels.role == opencti-core
+    image: opencti/connector-export-file-csv:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
@@ -145,18 +137,19 @@ services:
       - CONNECTOR_SCOPE=text/csv
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info=error
+      - CONNECTOR_LOG_LEVEL=info
+    restart: always
     depends_on:
       - opencti
+      - rabbitmq
 
   connector-export-file-txt:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-    image: opencti/connector-export-file-txt:6.1.1
+        - node.labels.role == opencti-core
+    image: opencti/connector-export-file-txt:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
@@ -164,48 +157,49 @@ services:
       - CONNECTOR_TYPE=INTERNAL_EXPORT_FILE
       - CONNECTOR_NAME=ExportFileTxt
       - CONNECTOR_SCOPE=text/plain
-
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info=error
+      - CONNECTOR_LOG_LEVEL=info
+    restart: always
     depends_on:
       - opencti
+      - rabbitmq
 
   connector-import-file-stix:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-    image: opencti/connector-import-file-stix:6.1.1
+        - node.labels.role == opencti-core
+    image: opencti/connector-import-file-stix:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
       - CONNECTOR_ID=${CONNECTOR_IMPORT_FILE_STIX_ID} # Valid UUIDv4
       - CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
       - CONNECTOR_NAME=ImportFileStix
-      - CONNECTOR_VALIDATE_BEFORE_IMPORT=false # Validate any bundle before import
+      - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
       - CONNECTOR_SCOPE=application/json,text/xml
       - CONNECTOR_AUTO=true # Enable/disable auto-import of file
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info=error
+      - CONNECTOR_LOG_LEVEL=info
+    restart: always
     depends_on:
       - opencti
-
+      - rabbitmq
+      
   connector-import-document:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-    image: opencti/connector-import-document:6.1.1
+        - node.labels.role == opencti-core
+    image: opencti/connector-import-document:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
-      - CONNECTOR_ID=${CONNECTOR_IMPORT_DOCUMENT_ID} # Valid UUIDv4
+      - CONNECTOR_ID=c3970f8a-ce4b-4497-a381-20b7256f56f0 # Valid UUIDv4
       - CONNECTOR_TYPE=INTERNAL_IMPORT_FILE
       - CONNECTOR_NAME=ImportDocument
       - CONNECTOR_VALIDATE_BEFORE_IMPORT=true # Validate any bundle before import
@@ -213,20 +207,20 @@ services:
       - CONNECTOR_AUTO=true # Enable/disable auto-import of file
       - CONNECTOR_ONLY_CONTEXTUAL=false # Only extract data related to an entity (a report, a threat actor, etc.)
       - CONNECTOR_CONFIDENCE_LEVEL=15 # From 0 (Unknown) to 100 (Fully trusted)
-      - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info=error
+      - CONNECTOR_LOG_LEVEL=error
       - IMPORT_DOCUMENT_CREATE_INDICATOR=true
+    restart: always
     depends_on:
       - opencti
-
+      - rabbitmq
+    
   connector-disarm-framework:
     deploy:
       replicas: 1
       placement:
         constraints:
-          - node.labels.role == opencti-core
-      restart_policy: *default_restart_policy
-    image: opencti/connector-disarm-framework:6.1.1
+        - node.labels.role == opencti-core
+    image: opencti/connector-disarm-framework:6.5.3
     environment:
       - OPENCTI_URL=${OPENCTI_CONNECT_URL}
       - OPENCTI_TOKEN=${OPENCTI_ADMIN_TOKEN}
@@ -236,46 +230,19 @@ services:
       - CONNECTOR_CONFIDENCE_LEVEL=75 # From 0 (Unknown) to 100 (Fully trusted)
       - CONNECTOR_RUN_AND_TERMINATE=false
       - OPENCTI_JSON_LOGGING=true # Enable / disable JSON logging
-      - CONNECTOR_LOG_LEVEL=info=error
+      - CONNECTOR_LOG_LEVEL=info
       - DISARM_FRAMEWORK_URL=https://raw.githubusercontent.com/DISARMFoundation/DISARMframeworks/main/generated_files/DISARM_STIX/DISARM.json
       - DISARM_FRAMEWORK_INTERVAL=7 # In days, must be strictly greater than 1
+    restart: always
     depends_on:
       - opencti
-    networks:
-      - cfa_opencti_network
+      - rabbitmq
 
-  portainer-agent:
-    image: portainer/agent
-    environment:
-      - AGENT_CLUSTER_ADDR=tasks.portainer-agent
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /var/lib/docker/volumes:/var/lib/docker/volumes
-    deploy:
-      mode: global
-    networks:
-      - cfa_opencti_network
-
-  portainer:
-    image: portainer/portainer
-    command: >
-      -H tcp://tasks.portainer-agent:9001 --tlsskipverify
-      --admin-password=${PORTAINER_ADMIN_PASSWORD}
-    environment:
-      - PORTAINER_ADMIN_PASSWORD=${PORTAINER_ADMIN_PASSWORD}
-    ports:
-      - "9010:9000"
-      - "8000:8000"
-    volumes:
-      - portainer_data:/data
-    deploy:
-      replicas: 1
-      placement:
-        constraints:
-          - node.role == manager
-    networks:
-      - cfa_opencti_network
-
+# volumes:
+#    esdata:
+#    s3data:
+#    redisdata:
+#    amqpdata:
 
 volumes:
   s3data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: redis:7.4.2
     volumes:
@@ -24,7 +24,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == manager
+          - node.labels.role == manager
     ports:
       - "80:80"
     depends_on:
@@ -49,7 +49,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: opencti/platform:6.5.3
     environment:
@@ -110,7 +110,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: opencti/connector-export-file-stix:6.5.3
     environment:
@@ -131,7 +131,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: opencti/connector-export-file-csv:6.5.3
     environment:
@@ -152,7 +152,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: opencti/connector-export-file-txt:6.5.3
     environment:
@@ -174,7 +174,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: opencti/connector-import-file-stix:6.5.3
     environment:
@@ -197,7 +197,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: opencti/connector-import-document:6.5.3
     environment:
@@ -221,7 +221,7 @@ services:
       replicas: 1
       placement:
         constraints:
-        - node.labels.role == opencti-core
+          - node.labels.role == opencti-core
       restart_policy: *default_restart_policy
     image: opencti/connector-disarm-framework:6.5.3
     environment:

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -2,6 +2,7 @@
 server {
     listen ${NGINX_PORT};
     server_name ${NGINX_OPENCTI_SERVER_NAME};
+    client_max_body_size 50M;
 
     location / {
         proxy_pass http://opencti:8080;


### PR DESCRIPTION
bumped versions from 6.1.1 to 6.5.3
removed restart policy for uniformity with the original and the deployed version.
added import document functionality.